### PR TITLE
Accept prefix from env for nix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ O=tsvcut.o
 P=tsvcut
 CFLAGS=-O2
 
-PREFIX=/usr/local
+PREFIX    ?=    /usr/local
 
 $P: $O
 	cc $(CFLAGS) $O -o $P


### PR DESCRIPTION
Nix packages need to override PREFIX path to $out to build packages properly in /nix/store path. This allows the current statically set PREFIX in addition to an environment variable being set to override PREFIX.